### PR TITLE
Add EventDispatcher support to MailerService

### DIFF
--- a/Classes/Service/MailerService.php
+++ b/Classes/Service/MailerService.php
@@ -15,6 +15,7 @@ namespace Neos\SymfonyMailer\Service;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\SymfonyMailer\Exception\InvalidMailerConfigurationException;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
@@ -33,13 +34,14 @@ class MailerService
      * Returns a mailer instance with the given transport or the configured default transport.
      *
      * @param TransportInterface|null $transport
+     * @param EventDispatcherInterface|null $dispatcher
      * @return Mailer
      * @throws InvalidMailerConfigurationException
      */
-    public function getMailer(TransportInterface $transport = null): Mailer
+    public function getMailer(TransportInterface $transport = null, ?EventDispatcherInterface $dispatcher = null): Mailer
     {
         if ($transport !== null) {
-            return new Mailer($transport);
+            return new Mailer($transport, null, $dispatcher);
         }
 
         // throw exception when dsn is not set
@@ -47,7 +49,7 @@ class MailerService
             throw new InvalidMailerConfigurationException('No DSN configured for Neos.SymfonyMailer', 1739540476);
         }
 
-        return new Mailer(Transport::fromDsn($this->mailerConfiguration['dsn']));
+        return new Mailer(Transport::fromDsn($this->mailerConfiguration['dsn'], $dispatcher), null, $dispatcher);
     }
 
     /**


### PR DESCRIPTION
- Adds an optional EventDispatcherInterface parameter to getMailer() method
- Maintains backward compatibility with existing code
- Enables listening to Symfony Mailer events (MessageEvent, SentMessageEvent, etc.)

This allows consuming packages to access debugging information like message IDs and transport debug data through Symfony's event system (see https://symfony.com/doc/current/mailer.html#debugging-emails).

For example you could define a simple event dispatcher that emits flow signals or execute any other logic.

```
<?php
declare(strict_types=1);

namespace Neos\SymfonyMailer\EventDispatcher;

use Neos\Flow\Annotations as Flow;
use Neos\Flow\SignalSlot\Dispatcher;
use Psr\EventDispatcher\EventDispatcherInterface;
use Symfony\Component\Mailer\Event\FailedMessageEvent;
use Symfony\Component\Mailer\Event\SentMessageEvent;

#[Flow\Scope("singleton")]
class FlowSignalEventDispatcher implements EventDispatcherInterface
{
    public function dispatch(object $event): object
    {
        if ($event instanceof SentMessageEvent) {
            $this->emitSentMessageEvent($event);
        } elseif ($event instanceof FailedMessageEvent) {
            $this->emitFailedMessageEvent($event);
        }

        return $event;
    }

    #[Flow\Signal]
    protected function emitSentMessageEvent(SentMessageEvent $event): void
    {}

    #[Flow\Signal]
    protected function emitFailedMessageEvent(FailedMessageEvent $event): void
    {}
}
```

If you think it makes sense, I could also include the above example as a default dispatcher with this PR.